### PR TITLE
Add trivy scan for release builds and add daily trivy scan build

### DIFF
--- a/.github/workflows/build-timestamped-master.yml
+++ b/.github/workflows/build-timestamped-master.yml
@@ -25,8 +25,6 @@ jobs:
           updatedVersion=$VERSION-$startTime-$latestCommit
           echo $updatedVersion
           sed -i "s/version=\(.*\)/version=$updatedVersion/g" gradle.properties
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,7 +3,7 @@ name: Publish release
 on:
   workflow_dispatch:
   repository_dispatch:
-    types: [stdlib-release-pipeline]
+    types: [ stdlib-release-pipeline ]
 
 jobs:
   publish-release:
@@ -16,6 +16,18 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 11
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew build -x check -x test
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '/github/workspace/ballerina/lib'
+          format: 'table'
+          exit-code: '1'
       - name: Set version env variable
         run: echo "VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)" >> $GITHUB_ENV
       - name: Pre release depenency version update
@@ -32,8 +44,6 @@ jobs:
           sed -i 's/stdlib\(.*\)=\(.*\)-[0-9]\{8\}-[0-9]\{6\}-.*$/stdlib\1=\2/g' gradle.properties
           git add gradle.properties
           git commit -m "Move dependencies to stable version" || echo "No changes to commit"
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Publish artifact
         env:
           BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,12 +1,14 @@
-name: Publish to the Ballerina central
+name: Trivy
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
-  publish-release:
+  ubuntu-build:
+    name: Build on Ubuntu
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'ballerina-platform'
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -26,11 +28,3 @@ jobs:
           scan-ref: '/github/workspace/ballerina/lib'
           format: 'table'
           exit-code: '1'
-      - name: Publish artifact
-        env:
-          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
-          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
-        run: |
-          ./gradlew clean build -PpublishToCentral=true

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ Ballerina OracleDB Library
 ===================
 
   [![Build](https://github.com/ballerina-platform/module-ballerinax-oracledb/actions/workflows/build-timestamped-master.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-oracledb/actions/workflows/build-timestamped-master.yml)
+  [![Trivy](https://github.com/ballerina-platform/module-ballerinax-oracledb/actions/workflows/trivy-scan.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-oracledb/actions/workflows/trivy-scan.yml)
   [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-oracledb.svg)](https://github.com/ballerina-platform/module-ballerinax-oracledb/commits/master)
   [![Github issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-standard-library/module/oracledb.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-standard-library/labels/module%2Foracledb)
-  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
   [![codecov](https://codecov.io/gh/ballerina-platform/module-ballerinax-oracledb/branch/master/graph/badge.svg)](https://codecov.io/gh/ballerina-platform/module-ballerinax-oracledb)
 
 The OracleDB library is one of the external library packages of the <a target="_blank" href="https://ballerina.io/"> Ballerina</a> language.


### PR DESCRIPTION
## Purpose
$title

This PR integrates the [Trivy](https://github.com/aquasecurity/trivy) vulnerability scanner for the repository file system and it will check and generate the report daily or on-demand and before the release.

Related issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/1849

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
