### PR TITLE
Tooling support for OracleDB module

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "oracledb"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Ballerina"]
 keywords = ["database", "client", "network", "SQL", "RDBMS", "OracleDB", "Oracle"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-oracledb"
@@ -9,10 +9,10 @@ license = ["Apache-2.0"]
 distribution = "slbeta3"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/oracledb-native-1.1.0.jar"
+path = "../native/build/libs/oracledb-native-1.1.1-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/sql-native-1.1.0.jar"
+path = "./lib/sql-native-1.1.1-20211126-000600-ddbfeed.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/ojdbc8-12.2.0.1.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+id = "oracledb-compiler-plugin"
+class = "io.ballerina.stdlib.oracledb.compiler.OracleDBCompilerPlugin"
+
+[[dependency]]
+path = "../compiler-plugin/build/libs/oracledb-compiler-plugin-1.1.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -9,7 +9,7 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.0.1"
+version = "2.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
@@ -23,7 +23,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.0.1"
+version = "3.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -46,7 +46,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.0.1"
+version = "1.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -62,7 +62,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.0.1"
+version = "2.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -110,7 +110,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.0.1"
+version = "2.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
@@ -213,7 +213,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.0.1"
+version = "2.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -225,7 +225,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.0.1"
+version = "2.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.0.1"
+version = "2.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
@@ -258,7 +258,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.0.1"
+version = "1.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -267,7 +267,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.0.1"
+version = "1.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -276,7 +276,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -290,7 +290,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.0.1"
+version = "2.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -312,7 +312,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -323,7 +323,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.0.1"
+version = "2.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "uuid"
-version = "1.0.1"
+version = "1.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
@@ -366,7 +366,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "oracledb"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -240,6 +240,3 @@ build.dependsOn ":${packageName}-native:build"
 test.dependsOn ":${packageName}-native:build"
 build.finalizedBy stopTestDockerContainers
 test.dependsOn startTestDockerContainers
-
-publishToMavenLocal.dependsOn build
-publish.dependsOn build

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -39,8 +39,11 @@ description = 'Ballerina - Oracle DB Ballerina Generator'
 def packageName = 'oracledb'
 def packageOrg = 'ballerinax'
 def tomlVersion = stripBallerinaExtensionVersion("${project.version}")
+
 def ballerinaTomlFilePlaceHolder = new File("${project.rootDir}/build-config/resources/Ballerina.toml")
+def compilerPluginTomlFilePlaceHolder = new File("${project.rootDir}/build-config/resources/CompilerPlugin.toml")
 def ballerinaTomlFile = new File("$project.projectDir/Ballerina.toml")
+def compilerPluginTomlFile = new File("$project.projectDir/CompilerPlugin.toml")
 
 def stripBallerinaExtensionVersion(String extVersion) {
     if (extVersion.matches(project.ext.timestampedVersionRegex)) {
@@ -81,8 +84,10 @@ task updateTomlFiles {
         newConfig = newConfig.replace('@oracledb.driver.version@', project.oracleDBDriverVersion)
         newConfig = newConfig.replace('@oracle.xdb.version@', project.oracleXDBVersion)
         newConfig = newConfig.replace('@oracle.xmlparserv2.version@', project.oracleXMLParserVersion)
-
         ballerinaTomlFile.text = newConfig
+
+        def newCompilerPluginToml = compilerPluginTomlFilePlaceHolder.text.replace("@project.version@", project.version)
+        compilerPluginTomlFile.text = newCompilerPluginToml
     }
 }
 
@@ -91,9 +96,9 @@ task commitTomlFiles {
         project.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml"
+                commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml CompilerPlugin.toml"
             } else {
-                commandLine 'sh', '-c', "git commit -m '[Automated] Update the native jar versions' Ballerina.toml Dependencies.toml"
+                commandLine 'sh', '-c', "git commit -m '[Automated] Update the native jar versions' Ballerina.toml Dependencies.toml CompilerPlugin.toml"
             }
         }
     }
@@ -238,5 +243,7 @@ startTestDockerContainers.dependsOn createTestDockerImage
 
 build.dependsOn ":${packageName}-native:build"
 test.dependsOn ":${packageName}-native:build"
+build.dependsOn ":${packageName}-compiler-plugin:build"
+test.dependsOn ":${packageName}-compiler-plugin:build"
 build.finalizedBy stopTestDockerContainers
 test.dependsOn startTestDockerContainers

--- a/build-config/resources/CompilerPlugin.toml
+++ b/build-config/resources/CompilerPlugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+id = "oracledb-compiler-plugin"
+class = "io.ballerina.stdlib.oracledb.compiler.OracleDBCompilerPlugin"
+
+[[dependency]]
+path = "../compiler-plugin/build/libs/oracledb-compiler-plugin-@project.version@.jar"

--- a/build.gradle
+++ b/build.gradle
@@ -126,5 +126,10 @@ release {
 }
 
 task build {
+    dependsOn("${packageName}-native:build")
     dependsOn("${packageName}-ballerina:build")
+    dependsOn("${packageName}-examples:build")
 }
+
+publishToMavenLocal.dependsOn build
+publish.dependsOn build

--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,7 @@ release {
 
 task build {
     dependsOn("${packageName}-native:build")
+    dependsOn("${packageName}-compiler-plugin:build")
     dependsOn("${packageName}-ballerina:build")
     dependsOn("${packageName}-compiler-plugin-tests:build")
     dependsOn("${packageName}-examples:build")

--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,7 @@ release {
 task build {
     dependsOn("${packageName}-native:build")
     dependsOn("${packageName}-ballerina:build")
+    dependsOn("${packageName}-compiler-plugin-tests:build")
     dependsOn("${packageName}-examples:build")
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [Tooling support for OracleDB module](https://github.com/ballerina-platform/ballerina-standard-library/issues/2283)
 
 ### Changed
 

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id 'java'
+    id 'checkstyle'
+    id 'com.github.spotbugs'
+}
+
+description = 'Ballerina - OracleDB Compiler Plugin Tests'
+
+dependencies {
+    checkstyle project(':checkstyle')
+    checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
+
+    // implementation project(':oracledb-compiler-plugin')
+
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+
+    implementation group: 'org.testng', name: 'testng', version: "${testngVersion}"
+}
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
+sourceCompatibility = JavaVersion.VERSION_11
+
+test {
+    systemProperty "ballerina.offline.flag", "true"
+    useTestNG() {
+        suites 'src/test/resources/testng.xml'
+    }
+    testLogging.showStandardStreams = true
+    testLogging {
+        events "PASSED", "FAILED", "SKIPPED"
+        afterSuite { desc, result ->
+            if (!desc.parent) { // will match the outermost suite
+                def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+                def startItem = '|  ', endItem = '  |'
+                def repeatLength = startItem.length() + output.length() + endItem.length()
+                println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+            }
+        }
+    }
+}
+
+spotbugsTest {
+    ignoreFailures = true
+    effort = "max"
+    reportLevel = "low"
+    reportsDir = file("$project.buildDir/reports/spotbugs")
+    def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
+    if (excludeFile.exists()) {
+        it.excludeFilter = excludeFile
+    }
+    reports {
+        text.enabled = true
+    }
+}
+
+spotbugsMain {
+    enabled false
+}
+
+task validateSpotbugs() {
+    doLast {
+        if (spotbugsMain.reports.size() > 0 &&
+                spotbugsMain.reports[0].destination.exists() &&
+                spotbugsMain.reports[0].destination.text.readLines().size() > 0) {
+            spotbugsMain.reports[0].destination?.eachLine {
+                println 'Failure: ' + it
+            }
+            throw new GradleException("Spotbugs rule violations were found.");
+        }
+    }
+}
+
+tasks.withType(Checkstyle) {
+    exclude '**/module-info.java'
+}
+
+checkstyle {
+    toolVersion "${project.puppycrawlCheckstyleVersion}"
+    configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
+    configProperties = ["suppressionFile": file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+}
+
+checkstyleMain {
+    enabled false
+}
+
+spotbugsTest.finalizedBy validateSpotbugs
+checkstyleTest.dependsOn ':checkstyle:downloadCheckstyleRuleFiles'
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}
+
+test.dependsOn ":oracledb-ballerina:build"
+build.dependsOn ":oracledb-ballerina:build"

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     checkstyle project(':checkstyle')
     checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
 
-    // implementation project(':oracledb-compiler-plugin')
+    implementation project(':oracledb-compiler-plugin')
 
     testImplementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
     testImplementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/oracledb/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/oracledb/compiler/CompilerPluginTest.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_101;
+import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_201;
+import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_202;
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_901;
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_902;
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.SQL_101;
@@ -137,6 +139,29 @@ public class CompilerPluginTest {
             Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
                     ORACLEDB_101.getMessage());
         });
+    }
+
+
+    @Test
+    public void testOutParameterValidations() {
+        Package currentPackage = loadPackage("sample4");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> errorDiagnosticsList = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR))
+                .collect(Collectors.toList());
+        long availableErrors = errorDiagnosticsList.size();
+
+        Assert.assertEquals(availableErrors, 2);
+
+        DiagnosticInfo diagnostic = errorDiagnosticsList.get(0).diagnosticInfo();
+        Assert.assertEquals(diagnostic.code(), ORACLEDB_201.getCode());
+        Assert.assertEquals(diagnostic.messageFormat(), ORACLEDB_201.getMessage());
+
+        diagnostic = errorDiagnosticsList.get(1).diagnosticInfo();
+        Assert.assertEquals(diagnostic.code(), ORACLEDB_202.getCode());
+        Assert.assertEquals(diagnostic.messageFormat(), ORACLEDB_202.getMessage());
+
     }
 
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/oracledb/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/oracledb/compiler/CompilerPluginTest.java
@@ -41,6 +41,7 @@ import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORAC
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_202;
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_901;
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_902;
+import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_903;
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.SQL_101;
 
 /**
@@ -141,7 +142,6 @@ public class CompilerPluginTest {
         });
     }
 
-
     @Test
     public void testOutParameterValidations() {
         Package currentPackage = loadPackage("sample4");
@@ -161,6 +161,32 @@ public class CompilerPluginTest {
         diagnostic = errorDiagnosticsList.get(1).diagnosticInfo();
         Assert.assertEquals(diagnostic.code(), ORACLEDB_202.getCode());
         Assert.assertEquals(diagnostic.messageFormat(), ORACLEDB_202.getMessage());
+
+    }
+
+    @Test
+    public void testOutParameterHint() {
+        Package currentPackage = loadPackage("sample5");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> errorDiagnosticsList = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR))
+                .collect(Collectors.toList());
+        long availableErrors = errorDiagnosticsList.size();
+
+        Assert.assertEquals(availableErrors, 1);
+
+        List<Diagnostic> hintDiagnosticsList = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.HINT))
+                .collect(Collectors.toList());
+        long availableHints = hintDiagnosticsList.size();
+
+        Assert.assertEquals(availableHints, 1);
+
+        hintDiagnosticsList.forEach(diagnostic -> {
+            Assert.assertEquals(diagnostic.diagnosticInfo().code(), ORACLEDB_903.getCode());
+            Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(), ORACLEDB_903.getMessage());
+        });
 
     }
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/oracledb/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/oracledb/compiler/CompilerPluginTest.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_901;
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_902;
+import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.SQL_101;
 
 /**
  * Tests the custom SQL compiler plugin.
@@ -86,6 +87,24 @@ public class CompilerPluginTest {
         DiagnosticInfo hint3 = diagnosticHints.get(2).diagnosticInfo();
         Assert.assertEquals(hint3.code(), ORACLEDB_901.getCode());
         Assert.assertEquals(hint3.messageFormat(), ORACLEDB_901.getMessage());
+    }
+
+    @Test
+    public void testSQLConnectionPoolFieldsInNewExpression() {
+        Package currentPackage = loadPackage("sample2");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> diagnosticErrorStream = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR))
+                .collect(Collectors.toList());
+        long availableErrors = diagnosticErrorStream.size();
+
+        Assert.assertEquals(availableErrors, 2);
+
+        diagnosticErrorStream.forEach(diagnostic -> {
+            Assert.assertEquals(diagnostic.diagnosticInfo().code(), SQL_101.getCode());
+            Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(), SQL_101.getMessage());
+        });
     }
 
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/oracledb/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/oracledb/compiler/CompilerPluginTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_101;
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_901;
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_902;
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.SQL_101;
@@ -99,11 +100,42 @@ public class CompilerPluginTest {
                 .collect(Collectors.toList());
         long availableErrors = diagnosticErrorStream.size();
 
-        Assert.assertEquals(availableErrors, 2);
+        Assert.assertEquals(availableErrors, 5);
+
+        for (int i = 0; i < diagnosticErrorStream.size(); i++) {
+            Diagnostic diagnostic = diagnosticErrorStream.get(i);
+            switch (i) {
+                case 0:
+                case 3:
+                case 4:
+                    Assert.assertEquals(diagnostic.diagnosticInfo().code(), ORACLEDB_101.getCode());
+                    Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
+                            ORACLEDB_101.getMessage());
+                    break;
+                default:
+                    Assert.assertEquals(diagnostic.diagnosticInfo().code(), SQL_101.getCode());
+                    Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
+                            SQL_101.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testOracleDBOptionRecord() {
+        Package currentPackage = loadPackage("sample3");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> diagnosticErrorStream = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR))
+                .collect(Collectors.toList());
+        long availableErrors = diagnosticErrorStream.size();
+
+        Assert.assertEquals(availableErrors, 7);
 
         diagnosticErrorStream.forEach(diagnostic -> {
-            Assert.assertEquals(diagnostic.diagnosticInfo().code(), SQL_101.getCode());
-            Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(), SQL_101.getMessage());
+            Assert.assertEquals(diagnostic.diagnosticInfo().code(), ORACLEDB_101.getCode());
+            Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
+                    ORACLEDB_101.getMessage());
         });
     }
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/oracledb/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/oracledb/compiler/CompilerPluginTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.oracledb.compiler;
+
+import io.ballerina.projects.DiagnosticResult;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.ProjectEnvironmentBuilder;
+import io.ballerina.projects.directory.BuildProject;
+import io.ballerina.projects.environment.Environment;
+import io.ballerina.projects.environment.EnvironmentBuilder;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Tests the custom SQL compiler plugin.
+ */
+public class CompilerPluginTest {
+
+    private static final Path RESOURCE_DIRECTORY = Paths.get("src", "test", "resources", "diagnostics")
+            .toAbsolutePath();
+    private static final Path DISTRIBUTION_PATH = Paths.get("../", "target", "ballerina-runtime")
+            .toAbsolutePath();
+
+    private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
+        Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
+        return ProjectEnvironmentBuilder.getBuilder(environment);
+    }
+
+    private Package loadPackage(String path) {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
+        BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath);
+        return project.currentPackage();
+    }
+
+    @Test
+    public void testBatchExecuteParam() {
+        Package currentPackage = loadPackage("sample1");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        long availableErrors = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR)).count();
+        Assert.assertEquals(availableErrors, 0);
+    }
+
+}

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample1/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample1/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "oracledb_test"
+name = "sample1"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/oracledb;
+
+public function main() returns error? {
+    oracledb:Client dbClient = check new();
+    check dbClient.close();
+}

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
@@ -18,5 +18,12 @@ import ballerinax/oracledb;
 
 public function main() returns error? {
     oracledb:Client dbClient = check new();
+    _ = check dbClient->query(``);
+    _ = check dbClient->queryRow(``);
+    check invokeQuery(dbClient);
     check dbClient.close();
+}
+
+function invokeQuery(oracledb:Client dbClient) returns error? {
+    _ = check dbClient->query(``);
 }

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample2/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample2/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "oracledb_test"
+name = "sample2"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample2/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample2/main.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/oracledb;
+
+oracledb:Client dbClient = check new oracledb:Client("url", (), (), (), 120, {}, { maxOpenConnections: -1 });
+
+public function main() returns error? {
+
+    oracledb:Client dbClient1 = check new("url", connectionPool = { maxOpenConnections: -1 });
+    check dbClient1.close();
+
+    oracledb:Client dbClient2 = check new("url", options = {});
+    check dbClient2.close();
+
+    oracledb:Client dbClient3 = check new("url", (), (), (), 120, {});
+    check dbClient3.close();
+}

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample3/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample3/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "oracledb_test"
+name = "sample3"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample3/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample3/main.bal
@@ -16,16 +16,28 @@
 
 import ballerinax/oracledb;
 
-oracledb:Client dbClient = check new oracledb:Client("url", (), (), (), 120, { loginTimeout: -2 }, { maxOpenConnections: -1 });
+public function main() {
 
-public function main() returns error? {
+    int id = 5;
 
-    oracledb:Client dbClient1 = check new("url", connectionPool = { maxOpenConnections: -1 });
-    check dbClient1.close();
+    int|oracledb:Options pool1 = 5;
 
-    oracledb:Client dbClient2 = check new("url", options = { loginTimeout: -2 });
-    check dbClient2.close();
+    int|oracledb:Options pool2 = {
+        loginTimeout: -2,
+        socketTimeout: -3
+    };
 
-    oracledb:Client dbClient3 = check new("url", (), (), (), 120, { loginTimeout: -2 });
-    check dbClient3.close();
+    oracledb:Options|int pool3 = {
+        loginTimeout: -2,
+        socketTimeout: -3
+    };
+
+    oracledb:Options pool4 = {
+        connectTimeout: -1,
+        socketTimeout: -1,
+        loginTimeout: -1
+    };
+
+    oracledb:Options pool5 = {
+    };
 }

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample4/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample4/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "oracledb_test"
+name = "sample4"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample4/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample4/main.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/oracledb;
+
+public function main() returns error? {
+    oracledb:IntervalYearToMonthOutParameter intervalOut = new();
+    int intVal = check intervalOut.get(int);
+
+    oracledb:XmlOutParameter xmlOut = new();
+    intVal = check xmlOut.get(int);
+}

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample5/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample5/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "oracledb_test"
+name = "sample5"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample5/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample5/main.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/oracledb;
+
+public function main() returns error? {
+    oracledb:XmlOutParameter xmlOut = new();
+    check xmlOut.get();
+}

--- a/compiler-plugin-tests/src/test/resources/testng.xml
+++ b/compiler-plugin-tests/src/test/resources/testng.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="SQL compiler plugin test suite" parallel="false">
+
+    <test name="SQL Compiler Plugin Tests" parallel="false">
+        <classes>
+            <class name="io.ballerina.stdlib.oracledb.compiler.CompilerPluginTest"/>
+        </classes>
+    </test>
+</suite>

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id 'java'
+    id 'checkstyle'
+    id 'com.github.spotbugs'
+}
+
+description = 'Ballerina - OracleDB Compiler Plugin'
+
+dependencies {
+    checkstyle project(':checkstyle')
+    checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
+
+    implementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+}
+
+def excludePattern = '**/module-info.java'
+tasks.withType(Checkstyle) {
+    exclude excludePattern
+}
+
+checkstyle {
+    toolVersion "${project.puppycrawlCheckstyleVersion}"
+    configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
+    configProperties = ["suppressionFile" : file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+}
+
+checkstyleMain.dependsOn(":checkstyle:downloadCheckstyleRuleFiles")
+
+spotbugsMain {
+    effort "max"
+    reportLevel "low"
+    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reports {
+        html.enabled true
+        text.enabled = true
+    }
+    def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
+    if(excludeFile.exists()) {
+        excludeFilter = excludeFile
+    }
+}
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Constants.java
@@ -23,6 +23,7 @@ package io.ballerina.stdlib.oracledb.compiler;
 public class Constants {
     public static final String BALLERINAX = "ballerinax";
     public static final String ORACLEDB = "oracledb";
+    public static final String CONNECTION_POOL_PARAM_NAME = "connectionPool";
 
     /**
      * Constants related to Client object.
@@ -32,4 +33,16 @@ public class Constants {
         public static final String QUERY = "query";
         public static final String QUERY_ROW = "queryRow";
     }
+
+    /**
+     * Constants for fields in sql:ConnectionPool.
+     */
+    public static class ConnectionPool {
+        public static final String MAX_OPEN_CONNECTIONS = "maxOpenConnections";
+        public static final String MAX_CONNECTION_LIFE_TIME = "maxConnectionLifeTime";
+        public static final String MIN_IDLE_CONNECTIONS = "minIdleConnections";
+    }
+
+    public static final String UNNECESSARY_CHARS_REGEX = "\"|\\n";
+
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Constants.java
@@ -54,6 +54,17 @@ public class Constants {
         public static final String LOGIN_TIMEOUT = "loginTimeout";
     }
 
+    /**
+     * Constants for fields in OutParameter objects.
+     */
+    public static class OutParameter {
+        public static final String METHOD_NAME = "get";
+        public static final String XML = "XmlOutParameter";
+        public static final String INTERVAL_YEAR_TO_MONTH = "IntervalYearToMonthOutParameter";
+        public static final String INTERVAL_DAY_TO_SECOND = "IntervalDayToSecondOutParameter";
+    }
+
+
     public static final String UNNECESSARY_CHARS_REGEX = "\"|\\n";
 
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Constants.java
@@ -25,6 +25,7 @@ public class Constants {
     public static final String ORACLEDB = "oracledb";
     public static final String CONNECTION_POOL_PARAM_NAME = "connectionPool";
     public static final String OPTIONS_PARAM_NAME = "options";
+    public static final String OUT_PARAMETER_POSTFIX = "OutParameter";
 
     /**
      * Constants related to Client object.

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Constants.java
@@ -24,6 +24,7 @@ public class Constants {
     public static final String BALLERINAX = "ballerinax";
     public static final String ORACLEDB = "oracledb";
     public static final String CONNECTION_POOL_PARAM_NAME = "connectionPool";
+    public static final String OPTIONS_PARAM_NAME = "options";
 
     /**
      * Constants related to Client object.
@@ -41,6 +42,16 @@ public class Constants {
         public static final String MAX_OPEN_CONNECTIONS = "maxOpenConnections";
         public static final String MAX_CONNECTION_LIFE_TIME = "maxConnectionLifeTime";
         public static final String MIN_IDLE_CONNECTIONS = "minIdleConnections";
+    }
+
+    /**
+     * Constants for fields in oracledb:Options.
+     */
+    public static class Options {
+        public static final String NAME = "Options";
+        public static final String CONNECT_TIMEOUT = "connectTimeout";
+        public static final String SOCKET_TIMEOUT = "socketTimeout";
+        public static final String LOGIN_TIMEOUT = "loginTimeout";
     }
 
     public static final String UNNECESSARY_CHARS_REGEX = "\"|\\n";

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Constants.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.oracledb.compiler;
+
+/**
+ * Constants for OracleDB compiler plugin.
+ */
+public class Constants {
+    public static final String BALLERINAX = "ballerinax";
+    public static final String ORACLEDB = "oracledb";
+
+    /**
+     * Constants related to Client object.
+     */
+    public static class Client {
+        public static final String NAME = "Client";
+        public static final String QUERY = "query";
+        public static final String QUERY_ROW = "queryRow";
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBCodeAnalyzer.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.CodeAnalysisContext;
 import io.ballerina.projects.plugins.CodeAnalyzer;
 import io.ballerina.stdlib.oracledb.compiler.analyzer.InitializerParamAnalyzer;
+import io.ballerina.stdlib.oracledb.compiler.analyzer.RecordAnalyzer;
 import io.ballerina.stdlib.oracledb.compiler.analyzer.RemoteMethodAnalyzer;
 
 import java.util.List;
@@ -36,5 +37,7 @@ public class OracleDBCodeAnalyzer extends CodeAnalyzer {
         ctx.addSyntaxNodeAnalysisTask(new RemoteMethodAnalyzer(), SyntaxKind.REMOTE_METHOD_CALL_ACTION);
         ctx.addSyntaxNodeAnalysisTask(new InitializerParamAnalyzer(),
                 List.of(SyntaxKind.IMPLICIT_NEW_EXPRESSION, SyntaxKind.EXPLICIT_NEW_EXPRESSION));
+        ctx.addSyntaxNodeAnalysisTask(new RecordAnalyzer(),
+                List.of(SyntaxKind.LOCAL_VAR_DECL, SyntaxKind.MODULE_VAR_DECL));
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBCodeAnalyzer.java
@@ -21,7 +21,10 @@ package io.ballerina.stdlib.oracledb.compiler;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.CodeAnalysisContext;
 import io.ballerina.projects.plugins.CodeAnalyzer;
+import io.ballerina.stdlib.oracledb.compiler.analyzer.InitializerParamAnalyzer;
 import io.ballerina.stdlib.oracledb.compiler.analyzer.RemoteMethodAnalyzer;
+
+import java.util.List;
 
 /**
  * OracleDB Code Analyzer.
@@ -29,7 +32,9 @@ import io.ballerina.stdlib.oracledb.compiler.analyzer.RemoteMethodAnalyzer;
 public class OracleDBCodeAnalyzer extends CodeAnalyzer {
 
     @Override
-    public void init(CodeAnalysisContext codeAnalysisContext) {
-        codeAnalysisContext.addSyntaxNodeAnalysisTask(new RemoteMethodAnalyzer(), SyntaxKind.REMOTE_METHOD_CALL_ACTION);
+    public void init(CodeAnalysisContext ctx) {
+        ctx.addSyntaxNodeAnalysisTask(new RemoteMethodAnalyzer(), SyntaxKind.REMOTE_METHOD_CALL_ACTION);
+        ctx.addSyntaxNodeAnalysisTask(new InitializerParamAnalyzer(),
+                List.of(SyntaxKind.IMPLICIT_NEW_EXPRESSION, SyntaxKind.EXPLICIT_NEW_EXPRESSION));
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBCodeAnalyzer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.oracledb.compiler;
+
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.projects.plugins.CodeAnalysisContext;
+import io.ballerina.projects.plugins.CodeAnalyzer;
+import io.ballerina.stdlib.oracledb.compiler.analyzer.RemoteMethodAnalyzer;
+
+/**
+ * OracleDB Code Analyzer.
+ */
+public class OracleDBCodeAnalyzer extends CodeAnalyzer {
+
+    @Override
+    public void init(CodeAnalysisContext codeAnalysisContext) {
+        codeAnalysisContext.addSyntaxNodeAnalysisTask(new RemoteMethodAnalyzer(), SyntaxKind.REMOTE_METHOD_CALL_ACTION);
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBCodeAnalyzer.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.CodeAnalysisContext;
 import io.ballerina.projects.plugins.CodeAnalyzer;
 import io.ballerina.stdlib.oracledb.compiler.analyzer.InitializerParamAnalyzer;
+import io.ballerina.stdlib.oracledb.compiler.analyzer.MethodAnalyzer;
 import io.ballerina.stdlib.oracledb.compiler.analyzer.RecordAnalyzer;
 import io.ballerina.stdlib.oracledb.compiler.analyzer.RemoteMethodAnalyzer;
 
@@ -39,5 +40,6 @@ public class OracleDBCodeAnalyzer extends CodeAnalyzer {
                 List.of(SyntaxKind.IMPLICIT_NEW_EXPRESSION, SyntaxKind.EXPLICIT_NEW_EXPRESSION));
         ctx.addSyntaxNodeAnalysisTask(new RecordAnalyzer(),
                 List.of(SyntaxKind.LOCAL_VAR_DECL, SyntaxKind.MODULE_VAR_DECL));
+        ctx.addSyntaxNodeAnalysisTask(new MethodAnalyzer(), SyntaxKind.METHOD_CALL);
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBCompilerPlugin.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBCompilerPlugin.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.oracledb.compiler;
+
+import io.ballerina.projects.plugins.CompilerPlugin;
+import io.ballerina.projects.plugins.CompilerPluginContext;
+
+/**
+ * Compiler plugin for OracleDB client.
+ */
+public class OracleDBCompilerPlugin extends CompilerPlugin {
+    @Override
+    public void init(CompilerPluginContext compilerPluginContext) {
+        compilerPluginContext.addCodeAnalyzer(new OracleDBCodeAnalyzer());
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBDiagnosticsCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBDiagnosticsCode.java
@@ -33,6 +33,8 @@ public enum OracleDBDiagnosticsCode {
     SQL_102("SQL_102", "invalid value: expected value is greater than zero", ERROR),
     SQL_103("SQL_103", "invalid value: expected value is greater than or equal to 30", ERROR),
 
+    ORACLEDB_101("ORACLEDB_101", "invalid value: expected value is greater than or equal to zero", ERROR),
+
     ORACLEDB_901("ORACLEDB_901",
             "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
     ORACLEDB_902("ORACLEDB_902",

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBDiagnosticsCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBDiagnosticsCode.java
@@ -19,12 +19,20 @@ package io.ballerina.stdlib.oracledb.compiler;
 
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
+import static io.ballerina.tools.diagnostics.DiagnosticSeverity.ERROR;
 import static io.ballerina.tools.diagnostics.DiagnosticSeverity.HINT;
 
 /**
  * Enum class to hold OracleDB module diagnostic codes.
  */
 public enum OracleDBDiagnosticsCode {
+
+    //SQL ConnectionPool Validations at init
+    // todo See if this can be taken from the dependency.
+    SQL_101("SQL_101", "invalid value: expected value is greater than one", ERROR),
+    SQL_102("SQL_102", "invalid value: expected value is greater than zero", ERROR),
+    SQL_103("SQL_103", "invalid value: expected value is greater than or equal to 30", ERROR),
+
     ORACLEDB_901("ORACLEDB_901",
             "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
     ORACLEDB_902("ORACLEDB_902",

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBDiagnosticsCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBDiagnosticsCode.java
@@ -35,6 +35,10 @@ public enum OracleDBDiagnosticsCode {
 
     ORACLEDB_101("ORACLEDB_101", "invalid value: expected value is greater than or equal to zero", ERROR),
 
+    // Out parameter return type validations diagnostics
+    ORACLEDB_201("ORACLEDB_201", "invalid value: expected value is either record or object", ERROR),
+    ORACLEDB_202("ORACLEDB_202", "invalid value: expected value is xml", ERROR),
+
     ORACLEDB_901("ORACLEDB_901",
             "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
     ORACLEDB_902("ORACLEDB_902",

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBDiagnosticsCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBDiagnosticsCode.java
@@ -42,7 +42,9 @@ public enum OracleDBDiagnosticsCode {
     ORACLEDB_901("ORACLEDB_901",
             "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
     ORACLEDB_902("ORACLEDB_902",
-            "parameter 'returnType' should be explicitly passed when the return data is ignored", HINT);
+            "parameter 'returnType' should be explicitly passed when the return data is ignored", HINT),
+    ORACLEDB_903("ORACLEDB_903",
+            "parameter 'typeDesc' should be explicitly passed when the return data is ignored", HINT);
 
     private final String code;
     private final String message;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBDiagnosticsCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/OracleDBDiagnosticsCode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.oracledb.compiler;
+
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import static io.ballerina.tools.diagnostics.DiagnosticSeverity.HINT;
+
+/**
+ * Enum class to hold OracleDB module diagnostic codes.
+ */
+public enum OracleDBDiagnosticsCode {
+    ORACLEDB_901("ORACLEDB_901",
+            "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
+    ORACLEDB_902("ORACLEDB_902",
+            "parameter 'returnType' should be explicitly passed when the return data is ignored", HINT);
+
+    private final String code;
+    private final String message;
+    private final DiagnosticSeverity severity;
+
+    OracleDBDiagnosticsCode(String code, String message, DiagnosticSeverity severity) {
+        this.code = code;
+        this.message = message;
+        this.severity = severity;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public DiagnosticSeverity getSeverity() {
+        return severity;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Utils.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.oracledb.compiler;
+
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+
+import java.util.Optional;
+
+/**
+ * Utils class.
+ */
+public class Utils {
+    public static boolean isOracleDBClientObject(SyntaxNodeAnalysisContext ctx, ExpressionNode node) {
+        Optional<TypeSymbol> objectType = ctx.semanticModel().typeOf(node);
+        if (objectType.isEmpty()) {
+            return false;
+        }
+        if (objectType.get().typeKind() == TypeDescKind.UNION) {
+            return ((UnionTypeSymbol) objectType.get()).memberTypeDescriptors().stream()
+                    .filter(typeDescriptor -> typeDescriptor instanceof TypeReferenceTypeSymbol)
+                    .map(typeReferenceTypeSymbol -> (TypeReferenceTypeSymbol) typeReferenceTypeSymbol)
+                    .anyMatch(Utils::isOracleDBClientObject);
+        }
+        if (objectType.get() instanceof TypeReferenceTypeSymbol) {
+            return isOracleDBClientObject(((TypeReferenceTypeSymbol) objectType.get()));
+        }
+        return false;
+    }
+
+    public static boolean isOracleDBClientObject(TypeReferenceTypeSymbol typeReference) {
+        Optional<ModuleSymbol> optionalModuleSymbol = typeReference.getModule();
+        if (optionalModuleSymbol.isEmpty()) {
+            return false;
+        }
+        ModuleSymbol module = optionalModuleSymbol.get();
+        if (!(module.id().orgName().equals(Constants.BALLERINAX) &&
+                module.id().moduleName().equals(Constants.ORACLEDB))) {
+            return false;
+        }
+        String objectName = typeReference.definition().getName().get();
+        return objectName.equals(Constants.Client.NAME);
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Utils.java
@@ -38,6 +38,8 @@ import java.util.Optional;
 
 import static io.ballerina.stdlib.oracledb.compiler.Constants.UNNECESSARY_CHARS_REGEX;
 import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_101;
+import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_201;
+import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_202;
 
 /**
  * Utils class.
@@ -109,5 +111,27 @@ public class Utils {
                     ((BasicLiteralNode) unaryExpressionNode.expression()).literalToken().text();
         }
         return value.replaceAll(UNNECESSARY_CHARS_REGEX, "");
+    }
+
+    public static DiagnosticInfo addDiagnosticsForInvalidTypes(String objectName, TypeDescKind requestedReturnType) {
+        switch(objectName) {
+            case Constants.OutParameter.INTERVAL_DAY_TO_SECOND:
+            case Constants.OutParameter.INTERVAL_YEAR_TO_MONTH:
+                // todo Verify needed specific record type
+                if (requestedReturnType == TypeDescKind.RECORD ||
+                        requestedReturnType == TypeDescKind.OBJECT) {
+                    return null;
+                }
+                return new DiagnosticInfo(ORACLEDB_201.getCode(), ORACLEDB_201.getMessage(),
+                        ORACLEDB_201.getSeverity());
+            case Constants.OutParameter.XML:
+                if (requestedReturnType == TypeDescKind.XML) {
+                    return null;
+                }
+                return new DiagnosticInfo(ORACLEDB_202.getCode(), ORACLEDB_202.getMessage(),
+                        ORACLEDB_202.getSeverity());
+            default:
+                return null;
+        }
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/Utils.java
@@ -22,10 +22,22 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingFieldNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
+import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
 
 import java.util.Optional;
+
+import static io.ballerina.stdlib.oracledb.compiler.Constants.UNNECESSARY_CHARS_REGEX;
+import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_101;
 
 /**
  * Utils class.
@@ -60,5 +72,42 @@ public class Utils {
         }
         String objectName = typeReference.definition().getName().get();
         return objectName.equals(Constants.Client.NAME);
+    }
+
+    public static void validateOptions(SyntaxNodeAnalysisContext ctx, MappingConstructorExpressionNode options) {
+        SeparatedNodeList<MappingFieldNode> fields = options.fields();
+        for (MappingFieldNode field : fields) {
+            String name = ((SpecificFieldNode) field).fieldName().toString()
+                    .trim().replaceAll(UNNECESSARY_CHARS_REGEX, "");
+            ExpressionNode valueNode = ((SpecificFieldNode) field).valueExpr().get();
+            switch (name) {
+                case Constants.Options.CONNECT_TIMEOUT:
+                case Constants.Options.LOGIN_TIMEOUT:
+                case Constants.Options.SOCKET_TIMEOUT:
+                    float timeoutVal = Float.parseFloat(getTerminalNodeValue(valueNode));
+                    if (timeoutVal < 0) {
+                        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(ORACLEDB_101.getCode(),
+                                ORACLEDB_101.getMessage(), ORACLEDB_101.getSeverity());
+                        ctx.reportDiagnostic(
+                                DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+                    }
+                    break;
+                default:
+                    // Can ignore all the other fields
+                    continue;
+            }
+        }
+    }
+
+    public static String getTerminalNodeValue(Node valueNode) {
+        String value = "";
+        if (valueNode instanceof BasicLiteralNode) {
+            value = ((BasicLiteralNode) valueNode).literalToken().text();
+        } else if (valueNode instanceof UnaryExpressionNode) {
+            UnaryExpressionNode unaryExpressionNode = (UnaryExpressionNode) valueNode;
+            value = unaryExpressionNode.unaryOperator() +
+                    ((BasicLiteralNode) unaryExpressionNode.expression()).literalToken().text();
+        }
+        return value.replaceAll(UNNECESSARY_CHARS_REGEX, "");
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/InitializerParamAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/InitializerParamAnalyzer.java
@@ -63,7 +63,7 @@ public class InitializerParamAnalyzer implements AnalysisTask<SyntaxNodeAnalysis
             }
         }
 
-        if (!(Utils.isOracleDBClientObject(ctx, ((ExpressionNode) ctx.node())))) {
+        if (!(Utils.isOracleDBObject(ctx, ((ExpressionNode) ctx.node()), Constants.Client.NAME))) {
             return;
         }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/InitializerParamAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/InitializerParamAnalyzer.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.oracledb.compiler.analyzer;
+
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
+import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
+import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingFieldNode;
+import io.ballerina.compiler.syntax.tree.NamedArgumentNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.PositionalArgumentNode;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
+import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.oracledb.compiler.Constants;
+import io.ballerina.stdlib.oracledb.compiler.Utils;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.stdlib.oracledb.compiler.Constants.CONNECTION_POOL_PARAM_NAME;
+import static io.ballerina.stdlib.oracledb.compiler.Constants.UNNECESSARY_CHARS_REGEX;
+import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.SQL_101;
+import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.SQL_102;
+import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.SQL_103;
+
+/**
+ * Validate fields of sql:Connection pool fields.
+ */
+public class InitializerParamAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    @Override
+    public void perform(SyntaxNodeAnalysisContext ctx) {
+        List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
+        for (Diagnostic diagnostic : diagnostics) {
+            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
+                return;
+            }
+        }
+
+        if (!(Utils.isOracleDBClientObject(ctx, ((ExpressionNode) ctx.node())))) {
+            return;
+        }
+
+        SeparatedNodeList<FunctionArgumentNode> arguments;
+        if (ctx.node() instanceof ImplicitNewExpressionNode) {
+            arguments = ((ImplicitNewExpressionNode) ctx.node()).parenthesizedArgList().get().arguments();
+        } else {
+            arguments = ((ExplicitNewExpressionNode) ctx.node()).parenthesizedArgList().arguments();
+        }
+
+        Optional<NamedArgumentNode> connectionPoolOptional = arguments.stream()
+                .filter(argNode -> argNode instanceof NamedArgumentNode)
+                .map(argNode -> (NamedArgumentNode) argNode)
+                .filter(arg -> arg.argumentName().name().text().equals(CONNECTION_POOL_PARAM_NAME))
+                .findFirst();
+        ExpressionNode connectionPool;
+        if (connectionPoolOptional.isPresent()) {
+            connectionPool = connectionPoolOptional.get().expression();
+        } else if (arguments.size() == 7) {
+            // All params are present
+            connectionPool = ((PositionalArgumentNode) arguments.get(6)).expression();
+        } else {
+            return;
+        }
+        SeparatedNodeList<MappingFieldNode> fields =
+                ((MappingConstructorExpressionNode) connectionPool).fields();
+        for (MappingFieldNode field : fields) {
+            String name = ((SpecificFieldNode) field).fieldName().toString()
+                    .trim().replaceAll(UNNECESSARY_CHARS_REGEX, "");
+            ExpressionNode valueNode = ((SpecificFieldNode) field).valueExpr().get();
+            switch (name) {
+                case Constants.ConnectionPool.MAX_OPEN_CONNECTIONS:
+                    int maxOpenConnections = Integer.parseInt(getTerminalNodeValue(valueNode));
+                    if (maxOpenConnections < 1) {
+                        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(SQL_101.getCode(), SQL_101.getMessage(),
+                                SQL_101.getSeverity());
+
+                        ctx.reportDiagnostic(
+                                DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+
+                    }
+                    break;
+                case Constants.ConnectionPool.MIN_IDLE_CONNECTIONS:
+                    int minIdleConnection = Integer.parseInt(getTerminalNodeValue(valueNode));
+                    if (minIdleConnection < 0) {
+                        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(SQL_102.getCode(), SQL_102.getMessage(),
+                                SQL_102.getSeverity());
+                        ctx.reportDiagnostic(
+                                DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+
+                    }
+                    break;
+                case Constants.ConnectionPool.MAX_CONNECTION_LIFE_TIME:
+                    float maxConnectionTime = Float.parseFloat(getTerminalNodeValue(valueNode));
+                    if (maxConnectionTime < 30) {
+                        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(SQL_103.getCode(), SQL_103.getMessage(),
+                                SQL_103.getSeverity());
+                        ctx.reportDiagnostic(
+                                DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+
+                    }
+                    break;
+                default:
+                    // Can ignore all the other fields
+                    continue;
+            }
+        }
+    }
+
+    private String getTerminalNodeValue(Node valueNode) {
+        String value;
+        if (valueNode instanceof BasicLiteralNode) {
+            value = ((BasicLiteralNode) valueNode).literalToken().text();
+        } else {
+            UnaryExpressionNode unaryExpressionNode = (UnaryExpressionNode) valueNode;
+            value = unaryExpressionNode.unaryOperator() +
+                    ((BasicLiteralNode) unaryExpressionNode.expression()).literalToken().text();
+        }
+        return value.replaceAll(UNNECESSARY_CHARS_REGEX, "");
+    }
+
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/MethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/MethodAnalyzer.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.oracledb.compiler.analyzer;
+
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
+import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.oracledb.compiler.Constants;
+import io.ballerina.stdlib.oracledb.compiler.Utils;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Code Analyser for OutParameter get method type validations.
+ */
+public class MethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    @Override
+    public void perform(SyntaxNodeAnalysisContext ctx) {
+        List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
+        for (Diagnostic diagnostic : diagnostics) {
+            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
+                return;
+            }
+        }
+
+        MethodCallExpressionNode methodCallExpNode = (MethodCallExpressionNode) ctx.node();
+        // Get the object type to validate arguments
+        ExpressionNode methodExpression = methodCallExpNode.expression();
+        Optional<TypeSymbol> methodExpReferenceType = ctx.semanticModel().typeOf(methodExpression);
+        if (methodExpReferenceType.isEmpty()) {
+            return;
+        }
+        if (methodExpReferenceType.get().typeKind() != TypeDescKind.TYPE_REFERENCE) {
+            return;
+        }
+        TypeReferenceTypeSymbol methodExpTypeSymbol = (TypeReferenceTypeSymbol) methodExpReferenceType.get();
+        Optional<ModuleSymbol> optionalModuleSymbol = methodExpTypeSymbol.getModule();
+        if (optionalModuleSymbol.isEmpty()) {
+            return;
+        }
+        ModuleSymbol module = optionalModuleSymbol.get();
+        if (!(module.id().orgName().equals(Constants.BALLERINAX)
+                && module.id().moduleName().equals(Constants.ORACLEDB))) {
+            return;
+        }
+        String objectName = ((TypeReferenceTypeSymbol) methodExpReferenceType.get()).definition().getName().get();
+
+        // Filter by method name, only OutParameter objects have get method
+        Optional<Symbol> methodSymbol = ctx.semanticModel().symbol(methodCallExpNode.methodName());
+        if (methodSymbol.isEmpty()) {
+            return;
+        }
+        Optional<String> methodName = methodSymbol.get().getName();
+        if (methodName.isEmpty()) {
+            return;
+        }
+        if (!methodName.get().equals(Constants.OutParameter.METHOD_NAME)) {
+            return;
+        }
+
+        // Filter by parameters length
+        SeparatedNodeList<FunctionArgumentNode> arguments = methodCallExpNode.arguments();
+        if (arguments.size() != 1) {
+            return;
+        }
+        TypeSymbol argumentTypeSymbol =
+                ((TypeSymbol) ctx.semanticModel().symbol(methodCallExpNode.arguments().get(0)).get());
+        TypeDescKind argTypeKind = argumentTypeSymbol.typeKind();
+        DiagnosticInfo diagnosticsForInvalidTypes = Utils.addDiagnosticsForInvalidTypes(objectName, argTypeKind);
+        if (diagnosticsForInvalidTypes != null) {
+            ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticsForInvalidTypes,
+                    methodCallExpNode.arguments().get(0).location()));
+        }
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/MethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/MethodAnalyzer.java
@@ -101,8 +101,11 @@ public class MethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
         if (arguments.size() != 1) {
             return;
         }
-        TypeSymbol argumentTypeSymbol =
-                ((TypeSymbol) ctx.semanticModel().symbol(node.arguments().get(0)).get());
+        Optional<Symbol> typeDescriptionArgument = ctx.semanticModel().symbol(node.arguments().get(0));
+        if (typeDescriptionArgument.isEmpty()) {
+            return;
+        }
+        TypeSymbol argumentTypeSymbol = ((TypeSymbol) typeDescriptionArgument.get());
         TypeDescKind argTypeKind = argumentTypeSymbol.typeKind();
         DiagnosticInfo diagnosticsForInvalidTypes = Utils.addDiagnosticsForInvalidTypes(objectName, argTypeKind);
         if (diagnosticsForInvalidTypes != null) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/MethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/MethodAnalyzer.java
@@ -39,22 +39,31 @@ import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import java.util.List;
 import java.util.Optional;
 
+import static io.ballerina.stdlib.oracledb.compiler.OracleDBDiagnosticsCode.ORACLEDB_903;
+import static org.ballerinalang.util.diagnostic.DiagnosticErrorCode.CANNOT_INFER_TYPE_FOR_PARAM;
+import static org.ballerinalang.util.diagnostic.DiagnosticErrorCode.INCOMPATIBLE_TYPE_FOR_INFERRED_TYPEDESC_VALUE;
+
 /**
  * Code Analyser for OutParameter get method type validations.
  */
 public class MethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
     @Override
     public void perform(SyntaxNodeAnalysisContext ctx) {
+        MethodCallExpressionNode node = (MethodCallExpressionNode) ctx.node();
         List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
-        for (Diagnostic diagnostic : diagnostics) {
-            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
-                return;
-            }
+        if (!diagnostics.isEmpty()) {
+            diagnostics.stream()
+                    .filter(diagnostic -> diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR)
+                    .filter(diagnostic ->
+                            diagnostic.diagnosticInfo().code().equals(CANNOT_INFER_TYPE_FOR_PARAM.diagnosticId()) ||
+                                    diagnostic.diagnosticInfo().code().equals(
+                                            INCOMPATIBLE_TYPE_FOR_INFERRED_TYPEDESC_VALUE.diagnosticId()))
+                    .filter(diagnostic -> diagnostic.location().lineRange().equals(node.location().lineRange()))
+                    .forEach(diagnostic -> addHint(ctx, node));
         }
 
-        MethodCallExpressionNode methodCallExpNode = (MethodCallExpressionNode) ctx.node();
         // Get the object type to validate arguments
-        ExpressionNode methodExpression = methodCallExpNode.expression();
+        ExpressionNode methodExpression = node.expression();
         Optional<TypeSymbol> methodExpReferenceType = ctx.semanticModel().typeOf(methodExpression);
         if (methodExpReferenceType.isEmpty()) {
             return;
@@ -75,7 +84,7 @@ public class MethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
         String objectName = ((TypeReferenceTypeSymbol) methodExpReferenceType.get()).definition().getName().get();
 
         // Filter by method name, only OutParameter objects have get method
-        Optional<Symbol> methodSymbol = ctx.semanticModel().symbol(methodCallExpNode.methodName());
+        Optional<Symbol> methodSymbol = ctx.semanticModel().symbol(node.methodName());
         if (methodSymbol.isEmpty()) {
             return;
         }
@@ -88,17 +97,41 @@ public class MethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
         }
 
         // Filter by parameters length
-        SeparatedNodeList<FunctionArgumentNode> arguments = methodCallExpNode.arguments();
+        SeparatedNodeList<FunctionArgumentNode> arguments = node.arguments();
         if (arguments.size() != 1) {
             return;
         }
         TypeSymbol argumentTypeSymbol =
-                ((TypeSymbol) ctx.semanticModel().symbol(methodCallExpNode.arguments().get(0)).get());
+                ((TypeSymbol) ctx.semanticModel().symbol(node.arguments().get(0)).get());
         TypeDescKind argTypeKind = argumentTypeSymbol.typeKind();
         DiagnosticInfo diagnosticsForInvalidTypes = Utils.addDiagnosticsForInvalidTypes(objectName, argTypeKind);
         if (diagnosticsForInvalidTypes != null) {
             ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticsForInvalidTypes,
-                    methodCallExpNode.arguments().get(0).location()));
+                    node.arguments().get(0).location()));
         }
+    }
+
+    private void addHint(SyntaxNodeAnalysisContext ctx, MethodCallExpressionNode node) {
+        if (!(Utils.isOracleDBObject(ctx, node.expression(), Constants.OUT_PARAMETER_POSTFIX))) {
+            return;
+        }
+        if (isGetMethod(ctx, node)) {
+            return;
+        }
+        ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(
+                new DiagnosticInfo(ORACLEDB_903.getCode(), ORACLEDB_903.getMessage(), ORACLEDB_903.getSeverity()),
+                node.location()));
+    }
+
+    private boolean isGetMethod(SyntaxNodeAnalysisContext ctx, MethodCallExpressionNode node) {
+        Optional<Symbol> methodSymbol = ctx.semanticModel().symbol(node.methodName());
+        if (methodSymbol.isEmpty()) {
+            return true;
+        }
+        Optional<String> methodName = methodSymbol.get().getName();
+        if (methodName.isEmpty()) {
+            return true;
+        }
+        return !methodName.get().equals(Constants.OutParameter.METHOD_NAME);
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/RecordAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/RecordAnalyzer.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.oracledb.compiler.analyzer;
+
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
+import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.oracledb.compiler.Constants;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.stdlib.oracledb.compiler.Constants.BALLERINAX;
+import static io.ballerina.stdlib.oracledb.compiler.Constants.ORACLEDB;
+import static io.ballerina.stdlib.oracledb.compiler.Utils.validateOptions;
+
+/**
+ * Analyser for validation oracledb:Options.
+ */
+public class RecordAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    @Override
+    public void perform(SyntaxNodeAnalysisContext ctx) {
+        List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
+        for (Diagnostic diagnostic : diagnostics) {
+            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
+                return;
+            }
+        }
+        Optional<Symbol> varSymOptional = ctx.semanticModel().symbol(ctx.node());
+        if (varSymOptional.isPresent()) {
+            TypeSymbol typeSymbol = ((VariableSymbol) varSymOptional.get()).typeDescriptor();
+
+            if (isOracleDBOptionsRecord(typeSymbol, Constants.Options.NAME)) {
+                Optional<MappingConstructorExpressionNode> recordNode = getRecordNode(ctx);
+                if (recordNode.isEmpty()) {
+                    return;
+                }
+                validateOptions(ctx, recordNode.get());
+            }
+        }
+    }
+
+    private Optional<MappingConstructorExpressionNode> getRecordNode(SyntaxNodeAnalysisContext ctx) {
+        // Initiated with a record
+        Optional<ExpressionNode> optionalInitializer;
+        if ((ctx.node() instanceof VariableDeclarationNode)) {
+            // Function level variables
+            optionalInitializer = ((VariableDeclarationNode) ctx.node()).initializer();
+        } else {
+            // Module level variables
+            optionalInitializer = ((ModuleVariableDeclarationNode) ctx.node()).initializer();
+        }
+        if (optionalInitializer.isEmpty()) {
+            return Optional.empty();
+        }
+        ExpressionNode initializer = optionalInitializer.get();
+        if (!(initializer instanceof MappingConstructorExpressionNode)) {
+            return Optional.empty();
+        }
+        return Optional.of((MappingConstructorExpressionNode) initializer);
+    }
+
+    private boolean isOracleDBOptionsRecord(TypeSymbol type, String recordName) {
+        if (type.typeKind() == TypeDescKind.UNION) {
+            return ((UnionTypeSymbol) type).memberTypeDescriptors().stream()
+                    .filter(typeDescriptor -> typeDescriptor instanceof TypeReferenceTypeSymbol)
+                    .map(typeReferenceTypeSymbol -> (TypeReferenceTypeSymbol) typeReferenceTypeSymbol)
+                    .anyMatch(typeReferenceTypeSymbol ->
+                            isOracleDBOptionsRecord(typeReferenceTypeSymbol, recordName));
+        }
+        if (type.typeKind() == TypeDescKind.TYPE_REFERENCE) {
+            return isOracleDBOptionsRecord((TypeReferenceTypeSymbol) type, recordName);
+        }
+        return false;
+    }
+
+    private boolean isOracleDBOptionsRecord(TypeReferenceTypeSymbol typeSymbol, String recordName) {
+        if (typeSymbol.typeDescriptor().typeKind() == TypeDescKind.RECORD) {
+            ModuleSymbol moduleSymbol = typeSymbol.getModule().get();
+            return ORACLEDB.equals(moduleSymbol.getName().get()) && BALLERINAX.equals(moduleSymbol.id().orgName())
+                    && typeSymbol.definition().getName().get().equals(recordName);
+        }
+        return false;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/RemoteMethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/RemoteMethodAnalyzer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.oracledb.compiler.analyzer;
+
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+
+/**
+ * OracleDB Client remote call analyzer.
+ */
+public class RemoteMethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
+
+    @Override
+    public void perform(SyntaxNodeAnalysisContext ctx) {
+        List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
+        for (Diagnostic diagnostic : diagnostics) {
+            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
+                return;
+            }
+        }
+    }
+
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/RemoteMethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/RemoteMethodAnalyzer.java
@@ -56,7 +56,7 @@ public class RemoteMethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisCont
     }
 
     private void addHint(SyntaxNodeAnalysisContext ctx, RemoteMethodCallActionNode node) {
-        if (!(Utils.isOracleDBClientObject(ctx, node.expression()))) {
+        if (!(Utils.isOracleDBObject(ctx, node.expression(), Constants.Client.NAME))) {
             return;
         }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/RemoteMethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/oracledb/compiler/analyzer/RemoteMethodAnalyzer.java
@@ -17,15 +17,12 @@
  */
 package io.ballerina.stdlib.oracledb.compiler.analyzer;
 
-import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
-import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
-import io.ballerina.compiler.api.symbols.TypeSymbol;
-import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.RemoteMethodCallActionNode;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.stdlib.oracledb.compiler.Constants;
+import io.ballerina.stdlib.oracledb.compiler.Utils;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticFactory;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
@@ -40,7 +37,7 @@ import static org.ballerinalang.util.diagnostic.DiagnosticErrorCode.CANNOT_INFER
 import static org.ballerinalang.util.diagnostic.DiagnosticErrorCode.INCOMPATIBLE_TYPE_FOR_INFERRED_TYPEDESC_VALUE;
 
 /**
- * PostgreSQL Client remote call analyzer.
+ * OracleDB Client remote call analyzer.
  */
 public class RemoteMethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
 
@@ -59,23 +56,7 @@ public class RemoteMethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisCont
     }
 
     private void addHint(SyntaxNodeAnalysisContext ctx, RemoteMethodCallActionNode node) {
-        ExpressionNode methodExpression = node.expression();
-        Optional<TypeSymbol> methodExpReferenceType = ctx.semanticModel().typeOf(methodExpression);
-        if (methodExpReferenceType.isEmpty()) {
-            return;
-        }
-        TypeReferenceTypeSymbol methodExpTypeSymbol = (TypeReferenceTypeSymbol) methodExpReferenceType.get();
-        Optional<ModuleSymbol> optionalModuleSymbol = methodExpTypeSymbol.getModule();
-        if (optionalModuleSymbol.isEmpty()) {
-            return;
-        }
-        ModuleSymbol module = optionalModuleSymbol.get();
-        if (!(module.id().orgName().equals(Constants.BALLERINAX) &&
-                module.id().moduleName().equals(Constants.ORACLEDB))) {
-            return;
-        }
-        String objectName = ((TypeReferenceTypeSymbol) methodExpReferenceType.get()).definition().getName().get();
-        if (!objectName.equals(Constants.Client.NAME)) {
+        if (!(Utils.isOracleDBClientObject(ctx, node.expression()))) {
             return;
         }
 

--- a/compiler-plugin/src/main/java/module-info.java
+++ b/compiler-plugin/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module io.ballerina.stdlib.oracledb.compiler {
+    requires io.ballerina.lang;
+    requires io.ballerina.tools.api;
+    requires io.ballerina.parser;
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@ githubSpotbugsVersion=4.0.5
 githubJohnrengelmanShadowVersion=5.2.0
 underCouchDownloadVersion=4.0.4
 researchgateReleaseVersion=2.8.0
+testngVersion=7.4.0
 ballerinaGradlePluginVersion=0.14.1
 
 ballerinaLangVersion=2.0.0-beta.5-20211125-162900-862e8e5a

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,11 +24,13 @@ rootProject.name = 'ballerina-oracledb'
 include ':checkstyle'
 include ':oracledb-native'
 include ':oracledb-ballerina'
+include ':oracledb-compiler-plugin-tests'
 include ':oracledb-examples'
 
 project(':checkstyle').projectDir = file("build-config${File.separator}checkstyle")
 project(':oracledb-native').projectDir = file('native')
 project(':oracledb-ballerina').projectDir = file('ballerina')
+project(':oracledb-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 project(':oracledb-examples').projectDir = file('examples')
 
 gradleEnterprise {

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,12 +23,14 @@ rootProject.name = 'ballerina-oracledb'
 
 include ':checkstyle'
 include ':oracledb-native'
+include ':oracledb-compiler-plugin'
 include ':oracledb-ballerina'
 include ':oracledb-compiler-plugin-tests'
 include ':oracledb-examples'
 
 project(':checkstyle').projectDir = file("build-config${File.separator}checkstyle")
 project(':oracledb-native').projectDir = file('native')
+project(':oracledb-compiler-plugin').projectDir = file('compiler-plugin')
 project(':oracledb-ballerina').projectDir = file('ballerina')
 project(':oracledb-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 project(':oracledb-examples').projectDir = file('examples')


### PR DESCRIPTION
## Purpose
$subject

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/2283

## Examples
- Validating nonzero int/float values for oracledb:Options in variable declaration and initialization,
<img width="717" alt="Screenshot 2021-11-28 at 01 13 40" src="https://user-images.githubusercontent.com/27669465/143720396-807bc68d-9878-4eae-90d7-e04abc002304.png">

- Validate fields of sql:ConnectionPool param in connector initialization,
<img width="1052" alt="Screenshot 2021-11-28 at 01 14 22" src="https://user-images.githubusercontent.com/27669465/143720415-ef639886-3689-4a1b-b180-ab6218c56d55.png">

- Validate supported types for get() method in OutParameters,
<img width="667" alt="Screenshot 2021-11-28 at 01 20 26" src="https://user-images.githubusercontent.com/27669465/143720422-4b94297a-3165-486b-a90d-d2dface80e15.png">

- Add hints when query() and queryRow() methods cannot infer the return type description.
- Add hints when get() method of OutParameters cannot infer the return type description.

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
