### PR TITLE
Add load label to deployments

### DIFF
--- a/load-tests/online_shop/deployment/deployment-patch.yaml
+++ b/load-tests/online_shop/deployment/deployment-patch.yaml
@@ -7,6 +7,7 @@ spec:
     metadata:
       labels:
         logs: "true"
+        load: "true"
     spec:
       containers:
       - name: "online-shop-deployment"

--- a/load-tests/online_shop/deployment/kustomization.yaml
+++ b/load-tests/online_shop/deployment/kustomization.yaml
@@ -8,4 +8,4 @@ patches:
       group: apps
       version: v1
       kind: Deployment
-      name: stored-procedures-deployment
+      name: online-shop-deployment

--- a/load-tests/online_shop/deployment/oracledb_deployment.yml
+++ b/load-tests/online_shop/deployment/oracledb_deployment.yml
@@ -52,6 +52,7 @@ spec:
       labels:
         app: oracledb
         logs: "true"
+        load: "true"
     spec:
       initContainers:
         - name: configdbora-downloader

--- a/load-tests/online_shop/scripts/run.sh
+++ b/load-tests/online_shop/scripts/run.sh
@@ -19,5 +19,5 @@
 set -e
 source base-scenario.sh
 
-jmeter -n -t "$scriptsDir/"http-requests.jmx -l "$resultsDir/"original-get.jtl -Jusers="$concurrent_users" -Jduration=600 -Jhost=bal.perf.test -Jport=80
+jmeter -n -t "$scriptsDir/"http-requests.jmx -l "$resultsDir/"original-measurement.jtl -Jusers="$concurrent_users" -Jduration=600 -Jhost=bal.perf.test -Jport=80
 tail "$resultsDir/"original-get.jtl

--- a/load-tests/online_shop/scripts/run.sh
+++ b/load-tests/online_shop/scripts/run.sh
@@ -20,4 +20,4 @@ set -e
 source base-scenario.sh
 
 jmeter -n -t "$scriptsDir/"http-requests.jmx -l "$resultsDir/"original-measurement.jtl -Jusers="$concurrent_users" -Jduration=600 -Jhost=bal.perf.test -Jport=80
-tail "$resultsDir/"original-get.jtl
+tail "$resultsDir/"original-measurement.jtl


### PR DESCRIPTION
## Purpose
Adds the load="true" label to the containers to indicate that the load test should not be executed until after the pods are running.

Related issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/2274

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
