### PR TITLE
Change load test output file name

### DIFF
--- a/load-tests/online_shop/scripts/run.sh
+++ b/load-tests/online_shop/scripts/run.sh
@@ -20,5 +20,5 @@ set -e
 source base-scenario.sh
 
 sleep 360
-jmeter -n -t "$scriptsDir/"http-requests.jmx -l "$resultsDir/"original-measurement.jtl -Jusers="$concurrent_users" -Jduration=600 -Jhost=bal.perf.test -Jport=80
-tail "$resultsDir/"original-measurement.jtl
+jmeter -n -t "$scriptsDir/"http-requests.jmx -l "$resultsDir/"original.jtl -Jusers="$concurrent_users" -Jduration=600 -Jhost=bal.perf.test -Jport=80
+tail "$resultsDir/"original.jtl


### PR DESCRIPTION
## Purpose
$subject

Fixes below error due to output results file being specified incorrectly
![image](https://user-images.githubusercontent.com/6332902/146502327-c70180ec-70df-4554-b6d1-c2c1edbcd7d2.png)


Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/2274

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
