### PR TITLE
Migrate to Gradle 9.5.1 and Java 25

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ jobs:
   call_workflow:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@java-25-migration
     secrets: inherit
     with:
       additional-windows-test-flags: "-x test"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,24 +1,24 @@
 [package]
 org = "ballerinax"
 name = "oracledb"
-version = "1.16.0"
+version = "1.16.1"
 authors = ["Ballerina"]
 keywords = ["Client", "Network", "SQL", "RDBMS", "OracleDB", "Vendor/Oracle", "Area/Database", "Type/Connector"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-oracledb"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.13.1"
+distribution = "2201.14.0-20260527-050400-74f7e6bf"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "oracledb-native"
-version = "1.16.0"
-path = "../native/build/libs/oracledb-native-1.16.0.jar"
+version = "1.16.1"
+path = "../native/build/libs/oracledb-native-1.16.1-SNAPSHOT.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "sql-native"
 version = "1.19.0"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "oracledb-compiler-plugin"
 class = "io.ballerina.stdlib.oracledb.compiler.OracleDBCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/oracledb-compiler-plugin-1.16.0.jar"
+path = "../compiler-plugin/build/libs/oracledb-compiler-plugin-1.16.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.1"
+distribution-version = "2201.14.0-20260527-050400-74f7e6bf"
 
 [[package]]
 org = "ballerina"
@@ -405,7 +405,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "oracledb"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -16,6 +16,49 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
+
+abstract class PatchBallerinaScriptsTask extends DefaultTask {
+    @Inject abstract JavaToolchainService getJavaToolchainService()
+
+    @TaskAction
+    void patch() {
+        def launcher = javaToolchainService.launcherFor { spec ->
+            spec.languageVersion.set(JavaLanguageVersion.of(25))
+        }.get()
+        def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
+
+        def binDirs = [
+            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
+            new File("${project.rootDir}/target/ballerina-runtime/bin")
+        ]
+        binDirs.each { binDir ->
+            if (binDir.exists()) {
+                binDir.eachFile { file ->
+                    file.setExecutable(true)
+                    if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
+                        def original = file.text
+                        def lines = original.split('\n').toList()
+                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
+                        if (shebangIdx >= 0) {
+                            lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
+                        }
+                        def patched = lines.join('\n') + '\n'
+                        if (patched != original) { file.text = patched }
+                    }
+                }
+            }
+        }
+    }
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -75,8 +118,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml CompilerPlugin.toml"
@@ -130,7 +174,7 @@ task createTestDockerImage(type: Exec) {
     }
 }
 
-def waitForContainerHealth(containerName) {
+def waitForContainerHealth(execOps, containerName) {
     def HEALTH_STATUS
     def counter = 0
     while (counter < 60) {
@@ -140,7 +184,7 @@ def waitForContainerHealth(containerName) {
             def cmd = !Os.isFamily(Os.FAMILY_WINDOWS) ?
                     ['sh', '-c', "docker inspect --format='{{json .State.Health.Status}}' ${containerName}"] :
                     ['cmd', '/c', "docker inspect --format=\"{{json .State.Health.Status}}\" ${containerName}"]
-            exec {
+            execOps.exec {
                 commandLine cmd
                 standardOutput = output
             }
@@ -161,7 +205,7 @@ def waitForContainerHealth(containerName) {
     return 1
 }
 
-def initializeDatabase(containerName) {
+def initializeDatabase(execOps, containerName) {
     println("Waiting for ${containerName} database to open.")
     sleep(70000)
     try {
@@ -169,7 +213,7 @@ def initializeDatabase(containerName) {
         def cmd = Os.isFamily(Os.FAMILY_WINDOWS) ?
                 ['cmd', '/c', "docker exec ${containerName} /bin/bash -c 'cd /home/oracle && source .bashrc; sh ./sql-scripts/run-sql-scripts.sh'"] :
                 ['sh', '-c', "docker exec ${containerName} /bin/bash -c 'cd /home/oracle && source .bashrc; sh ./sql-scripts/run-sql-scripts.sh'"]
-        temp = exec {
+        temp = execOps.exec {
             commandLine cmd ?: []
         }.exitValue
         return temp
@@ -179,20 +223,20 @@ def initializeDatabase(containerName) {
     }
 }
 
-def startDockerContainer(containerName, port, sslPort) {
+def startDockerContainer(execOps, containerName, port, sslPort) {
     def cmd = !Os.isFamily(Os.FAMILY_WINDOWS) ?
             ['sh', '-c', "docker run --rm -d --name ${containerName} -p ${port}:1521 -p ${sslPort}:2484 -t ballerina-oracledb"] :
             ['cmd', '/c', "docker run --rm -d --name ${containerName} -p ${port}:1521 -p ${sslPort}:2484 -t ballerina-oracledb"]
-    exec {
+    execOps.exec {
         commandLine cmd ?: []
     }
-    def healthCheck = waitForContainerHealth(containerName)
+    def healthCheck = waitForContainerHealth(execOps, containerName)
     if (healthCheck != 0) {
         throw new GradleException("Docker container '${containerName}' health test failed!")
     }
     println("Docker container '${containerName}' health test passed!")
 
-    def initializeCheck = initializeDatabase(containerName)
+    def initializeCheck = initializeDatabase(execOps, containerName)
     if (initializeCheck != 0) {
         throw new GradleException("Failed to initialize the database!")
     }
@@ -200,18 +244,19 @@ def startDockerContainer(containerName, port, sslPort) {
 }
 
 task startTestDockerContainers() {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        startDockerContainer("ballerina-oracledb", 1521, 2484)
+        startDockerContainer(execHelper.execOperations, "ballerina-oracledb", 1521, 2484)
     }
 }
 
-def stopTestDockerContainer(containerName) {
+def stopTestDockerContainer(execOps, containerName) {
     try {
         def stdOut = new ByteArrayOutputStream()
         def cmd = !Os.isFamily(Os.FAMILY_WINDOWS) ?
                 ['sh', '-c', "docker stop ${containerName}"] :
                 ['cmd', '/c', "docker stop ${containerName}"]
-        exec {
+        execOps.exec {
             commandLine cmd
             standardOutput = stdOut
         }
@@ -221,11 +266,16 @@ def stopTestDockerContainer(containerName) {
 }
 
 task stopTestDockerContainers() {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        stopTestDockerContainer("ballerina-oracledb")
+        stopTestDockerContainer(execHelper.execOperations, "ballerina-oracledb")
     }
 }
 
+
+task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
+    dependsOn 'unpackJballerinaTools'
+}
 
 updateTomlFiles.dependsOn copyStdlibs
 startTestDockerContainers.dependsOn createTestDockerImage
@@ -237,3 +287,7 @@ build.dependsOn ":${packageName}-compiler-plugin:build"
 test.dependsOn ":${packageName}-compiler-plugin:build"
 build.finalizedBy stopTestDockerContainers
 test.dependsOn startTestDockerContainers
+
+build.dependsOn patchBallerinaScripts
+test.dependsOn patchBallerinaScripts
+copyStdlibs.dependsOn patchBallerinaScripts

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -27,6 +27,8 @@ abstract class BallerinaExecHelper {
 
 abstract class PatchBallerinaScriptsTask extends DefaultTask {
     @Inject abstract JavaToolchainService getJavaToolchainService()
+    @Input abstract Property<String> getJballerinaToolsBinPath()
+    @Input abstract Property<String> getBallerinaRuntimeBinPath()
 
     @TaskAction
     void patch() {
@@ -35,20 +37,16 @@ abstract class PatchBallerinaScriptsTask extends DefaultTask {
         }.get()
         def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
 
-        def binDirs = [
-            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
-            new File("${project.rootDir}/target/ballerina-runtime/bin")
-        ]
-        binDirs.each { binDir ->
+        [new File(jballerinaToolsBinPath.get()), new File(ballerinaRuntimeBinPath.get())].each { binDir ->
             if (binDir.exists()) {
                 binDir.eachFile { file ->
                     file.setExecutable(true)
                     if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
                         def original = file.text
                         def lines = original.split('\n').toList()
-                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        lines = lines.collect { it.replace('--sun-misc-unsafe-memory-access=allow', '').trim() }.findAll { !it.isEmpty() }
                         def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
-                        if (shebangIdx >= 0) {
+                        if (shebangIdx >= 0 && !lines.any { it.startsWith('export JAVA_HOME=') }) {
                             lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
                         }
                         def patched = lines.join('\n') + '\n'
@@ -275,6 +273,9 @@ task stopTestDockerContainers() {
 
 task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
     dependsOn 'unpackJballerinaTools'
+    outputs.upToDateWhen { !tasks.named('unpackJballerinaTools').get().didWork }
+    jballerinaToolsBinPath = layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
+    ballerinaRuntimeBinPath = "${rootProject.projectDir.absolutePath}/target/ballerina-runtime/bin"
 }
 
 updateTomlFiles.dependsOn copyStdlibs

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,18 +7,18 @@ keywords = ["Client", "Network", "SQL", "RDBMS", "OracleDB", "Vendor/Oracle", "A
 repository = "https://github.com/ballerina-platform/module-ballerinax-oracledb"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.13.1"
+distribution = "2201.14.0-20260527-050400-74f7e6bf"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "oracledb-native"
 version = "@toml.version@"
 path = "../native/build/libs/oracledb-native-@project.version@.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "sql-native"
 version = "@sql.version@"

--- a/build-config/spotbugs-exclude.xml
+++ b/build-config/spotbugs-exclude.xml
@@ -34,4 +34,14 @@
         <Class name="io.ballerina.stdlib.oracledb.parameterprocessor.OracleDBStatementParameterProcessor"/>
         <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR"/>
     </Match>
+    <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
+    <Match>
+        <BugCode name="THROWS"/>
+    </Match>
+    <Match>
+        <BugCode name="AT"/>
+    </Match>
+    <Match>
+        <BugCode name="USELESS_STRING"/>
+    </Match>
 </FindBugsFilter>

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ allprojects {
     version = project.version
 
     apply plugin: 'jacoco'
+jacoco {
+    toolVersion = jacocoVersion
+}
     apply plugin: 'maven-publish'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,14 @@ allprojects {
 
 subprojects {
 
+    plugins.withId('java') {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        }
+    }
+
     configurations {
         externalJars
         ballerinaStdLibs
@@ -123,7 +131,7 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn("${packageName}-native:build")
     dependsOn("${packageName}-compiler-plugin:build")
     dependsOn("${packageName}-ballerina:build")

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     checkstyle project(':checkstyle')
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstylePluginVersion}"
 
-    jacocoRuntime "org.jacoco:org.jacoco.agent:0.8.10:runtime"
+    jacocoRuntime "org.jacoco:org.jacoco.agent:${jacocoVersion}:runtime"
 
     implementation project(':oracledb-compiler-plugin')
 
@@ -47,8 +47,6 @@ dependencies {
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
-
-sourceCompatibility = JavaVersion.VERSION_21
 
 test {
     systemProperty "ballerina.offline.flag", "true"
@@ -85,13 +83,13 @@ spotbugsTest {
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
     ignoreFailures = true
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile
     }
     reports {
-        text.enabled = true
+        text.required = true
     }
 }
 

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -52,10 +52,10 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     reports {
-        html.enabled true
-        text.enabled = true
+        html.required = true
+        text.required = true
     }
     def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
     if(excludeFile.exists()) {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -17,6 +17,12 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class ExamplesExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 apply plugin: 'java'
 
@@ -34,13 +40,14 @@ clean {
 def graalvmFlag = ""
 
 task testExamples {
+    def execHelper = project.objects.newInstance(ExamplesExecHelper)
     if (project.hasProperty('balGraalVMTest')) {
         graalvmFlag = '--graalvm'
     }
     doLast {
         examples.each { example ->
             try {
-                exec {
+                execHelper.execOperations.exec {
                     workingDir "${project.projectDir}/${example}"
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                         commandLine 'cmd', '/c', "${ballerinaDist}/bin/bal.bat test --offline ${graalvmFlag} && exit %%ERRORLEVEL%%"
@@ -57,6 +64,7 @@ task testExamples {
 }
 
 task buildExamples {
+    def execHelper = project.objects.newInstance(ExamplesExecHelper)
     gradle.taskGraph.whenReady { graph ->
         if (graph.hasTask(":java.oracledb-examples:test")) {
             buildExamples.enabled = false
@@ -65,7 +73,7 @@ task buildExamples {
     doLast {
         examples.each { example ->
             try {
-                exec {
+                execHelper.execOperations.exec {
                     workingDir project.projectDir
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                         commandLine 'cmd', '/c', "${ballerinaDist}/bin/bal.bat pack --offline ${example} && exit %%ERRORLEVEL%%"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0
 releasePluginVersion=3.1.0
 ballerinaGradlePluginVersion=4.0.0
-jacocoVersion=0.8.13
+jacocoVersion=0.8.14
 testngVersion=7.6.1
 
 # Direct Dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,15 @@
 group=io.ballerina.stdlib
 version=1.16.1-SNAPSHOT
 
-ballerinaLangVersion=2201.13.1
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 oracleDBDriverVersion=23.2.0.0
 checkstylePluginVersion=10.12.1
-spotbugsPluginVersion=6.0.18
+spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
-ballerinaGradlePluginVersion=2.3.0
+releasePluginVersion=3.1.0
+ballerinaGradlePluginVersion=4.0.0
+jacocoVersion=0.8.13
 testngVersion=7.6.1
 
 # Direct Dependencies

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,3 +5,4 @@ networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -43,10 +43,8 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
-
 jacoco {
-    toolVersion = "0.8.10"
+    toolVersion = "0.8.13"
 }
 
 test {
@@ -58,7 +56,7 @@ test {
     }
     jacoco {
         enabled = true
-        destinationFile = file("$buildDir/coverage-reports/jacoco.exec")
+        destinationFile = layout.buildDirectory.file("coverage-reports/jacoco.exec").get().asFile
         includeNoLocationClasses = true
     }
 }
@@ -69,13 +67,13 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile
     }
     reports {
-        text.enabled = true
+        text.required = true
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,7 +25,6 @@ pluginManagement {
     }
 
     repositories {
-        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,6 +25,7 @@ pluginManagement {
     }
 
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'
@@ -37,7 +38,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'ballerina-oracledb'
@@ -56,9 +57,9 @@ project(':oracledb-ballerina').projectDir = file('ballerina')
 project(':oracledb-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 project(':oracledb-examples').projectDir = file('examples')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
     }
 }


### PR DESCRIPTION
## Summary

- **Gradle 9.5.1**: Upgrade wrapper; replace removed `buildDir` API with `layout.buildDirectory`; replace `Project.exec()` with `ExecOperations` injection; migrate from `com.gradle.enterprise` to `com.gradle.develocity`; upgrade `net.researchgate.release` to 3.1.0
- **Java 25**: Add Java 25 toolchain to all subprojects; upgrade Ballerina Gradle plugin to 4.0.0 and `ballerinaLangVersion` to `2201.14.0-20260527-050400-74f7e6bf`; update all `[platform.java21]` TOML sections to `[platform.java25]`; add `patchBallerinaScripts` task to remove the `--sun-misc-unsafe-memory-access=allow` JVM flag (removed in Java 25) from the extracted `bal` binary after unpack; wire `test.dependsOn patchBallerinaScripts` to ensure patching during split CI builds
- **SpotBugs 6.5.1**: Upgrade for Java 25 class file support (requires SpotBugs 4.9.x / ASM 9.7+); add exclusions for `THROWS`, `AT`, and `USELESS_STRING` detectors introduced in SpotBugs 4.9.x
- **JaCoCo 0.8.13**: Upgrade for Java 25 class file instrumentation support
- **CI workflow**: Update to `pull-request-build-template.yml@java-25-migration` for JDK 25 runner support

## Test plan
- [ ] `./gradlew build` passes green locally (full build including tests)
- [ ] `.bala` artifact is created as `*-java25-*.bala`
- [ ] SpotBugs passes on native module and compiler-plugin-tests
- [ ] CI passes on both Ubuntu and Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request upgrades the project to Gradle 9.5.1 and Java 25, implementing all necessary compatibility changes across the build configuration, Ballerina modules, and dependencies.

## Key Changes

**Build System Upgrade**
- Gradle wrapper updated from 8.11.1 to 9.5.1
- Replaced deprecated `buildDir` API with `layout.buildDirectory` across build scripts
- Migrated from `Project.exec()` to injected `ExecOperations` for improved Gradle task encapsulation
- Migrated from `com.gradle.enterprise` to `com.gradle.develocity` plugin (version 3.19.2)
- Updated terminology from `termsOfServiceUrl/termsOfServiceAgree` to `termsOfUseUrl/termsOfUseAgree` in build scan configuration

**Java 25 Toolchain Configuration**
- Added Java 25 language version toolchain to all subprojects
- Replaced deprecated `sourceCompatibility`/`targetCompatibility` declarations with toolchain configuration
- Updated JaCoCo from version 0.8.10 to 0.8.13 for Java 25 bytecode instrumentation support

**Plugin & Dependency Updates**
- Upgraded Ballerina Gradle plugin to 4.0.0
- Upgraded SpotBugs plugin to 6.5.1 with exclusions for newly introduced detectors (THROWS, AT, USELESS_STRING)
- Upgraded net.researchgate.release plugin to 3.1.0

**Ballerina Module Updates**
- Package version bumped to 1.16.1
- Updated Ballerina distribution to 2201.14.0-20260527-050400-74f7e6bf
- Platform configuration migrated from `[platform.java21]` to `[platform.java25]` in Ballerina.toml files
- Updated native and compiler plugin dependencies to reference version 1.16.1 artifacts

**Java 25 Compatibility Handling**
- Added `PatchBallerinaScriptsTask` to remove a deprecated JVM flag from extracted Ballerina scripts and configure Java 25 as the runtime environment
- Wired patching task into build lifecycle for build, test, and copyStdlibs tasks to ensure compatibility

**CI/Workflow Updates**
- Updated pull request workflow to reference `pull-request-build-template.yml@java-25-migration` for Java 25 runner support

## Code Organization Improvements
- Introduced `BallerinaExecHelper` and `ExamplesExecHelper` abstract classes to centralize `ExecOperations` injection
- Refactored helper functions to accept `ExecOperations` parameter instead of relying on project context
- Updated SpotBugs report configuration to use `required = true` instead of deprecated `enabled = true` syntax

## Artifacts
- Generated `.bala` artifact now labeled with `java25` designation (e.g., `*-java25-*.bala`)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerinax-oracledb/pull/1031?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->